### PR TITLE
Trigger release action on content updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
     tags: ["v*.*.*"]
   pull_request:
     branches: ["main"]
+  repository_dispatch:
+    types: ["content_updated"]
 
 jobs:
   release:


### PR DESCRIPTION
## Why
Content updates are dispatched by the sync workflow, but the release job only runs on tags or PRs. This ensures releases can run when new content is pushed.

## What
Add a repository_dispatch trigger for the content_updated event.

## Impact
Release workflow can be triggered by content sync without affecting existing tag/PR triggers.

## Testing
Not run (workflow trigger change only).
