### PR TITLE
CI: Fix content submodule sync by using checkout instead of merge

### DIFF
--- a/.github/workflows/sync-contents.yml
+++ b/.github/workflows/sync-contents.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Sync posts to obsidian vault
         id: check
         run: |
-          git submodule update --remote --merge
+          git submodule update --remote --checkout
           if git status --porcelain | grep .; then
             echo "changed=true" >> $GITHUB_OUTPUT
             git config user.name "github-actions[bot]"


### PR DESCRIPTION
### Summary

This PR fixes the content sync workflow by changing how the Obsidian vault
submodule is updated.

The workflow previously attempted to update the submodule using
`git submodule update --remote --merge`, which caused failures when the
submodule history diverged or was rewritten.

The sync logic now uses `--checkout` to always align the submodule to the
current remote HEAD.

---

### Why

The Obsidian vault is a **content repository**, not a code dependency.

- Its history may be rewritten (e.g. re-init, force-push, cleanup).
- Merging histories is unnecessary and unsafe for CI automation.
- The blog only needs a deterministic pointer to the latest content state.

Using `--checkout` correctly reflects this model and avoids
`refusing to merge unrelated histories` errors.

---

### Impact

- Prevents CI failures caused by divergent submodule histories.
- Makes content sync deterministic and idempotent.
- Does not affect application code or release behavior.

---

### Notes

- This change is limited to the content sync workflow.
- No changes are required in the Obsidian vault repository.