### PR TITLE
Add `id-token` permission into `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### Why `id-token: write` is required

This workflow uses **keyless signing with Sigstore (cosign)**.
To perform keyless signing, the workflow must request a short-lived OIDC token
from GitHub’s OIDC provider.

The `id-token: write` permission is required to **request and mint** this token.
Without it, cosign falls back to an interactive device flow, which breaks
non-interactive CI execution.

This permission does not grant long-lived credentials and is scoped to the
workflow execution only.
