### PR TITLE
Refactor prose styling for reusability

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@10.28.1",
   "dependencies": {
     "@astrojs/react": "^4.4.2",
     "@radix-ui/react-avatar": "^1.1.11",
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.18",
     "@types/node": "^22.10.2",
     "@types/react": "^19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.6
         version: 0.9.6(prettier@3.7.4)(typescript@5.9.3)
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.1.18)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@6.4.1(@types/node@22.19.5)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
@@ -1087,6 +1090,11 @@ packages:
     resolution: {integrity: sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==}
     engines: {node: '>= 10'}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tailwindcss/vite@4.1.18':
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
@@ -2073,6 +2081,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2450,6 +2462,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -3599,6 +3614,11 @@ snapshots:
       '@tailwindcss/oxide-wasm32-wasi': 4.1.18
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
+
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.1.18)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.1.18
 
   '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@22.19.5)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
     dependencies:
@@ -4889,6 +4909,11 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -5303,6 +5328,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  util-deprecate@1.0.2: {}
 
   vfile-location@5.0.3:
     dependencies:

--- a/src/lib/prose.ts
+++ b/src/lib/prose.ts
@@ -1,0 +1,54 @@
+import { cn } from "@/lib/utils";
+
+export const proseClasses = cn(
+  // Base
+  "prose prose-neutral dark:prose-invert max-w-none",
+
+  // Body text
+  "prose-p:text-base md:prose-p:text-[1.0625rem]",
+  "prose-p:leading-7 md:prose-p:leading-8",
+
+  // Lead / emphasis
+  "prose-lead:text-lg md:prose-lead:text-xl",
+  "prose-lead:leading-8 md:prose-lead:leading-9",
+
+  "prose-small:text-sm prose-small:leading-6",
+
+  // Headings
+  "prose-h1:text-3xl md:prose-h1:text-4xl prose-h1:leading-tight",
+  "prose-h2:text-2xl md:prose-h2:text-3xl prose-h2:leading-snug",
+  "prose-h3:text-xl md:prose-h3:text-2xl prose-h3:leading-snug",
+  "prose-h4:text-lg prose-h4:leading-snug",
+  "prose-h5:text-base prose-h5:leading-normal",
+  "prose-h6:text-sm prose-h6:leading-normal",
+
+  "prose-headings:font-semibold prose-headings:tracking-tight",
+  "prose-headings:scroll-mt-24",
+
+  // Blockquote
+  "prose-blockquote:text-lg md:prose-blockquote:text-xl",
+  "prose-blockquote:leading-8 md:prose-blockquote:leading-9",
+  "prose-blockquote:border-l-4 prose-blockquote:pl-6",
+  "prose-blockquote:not-italic",
+
+  // Lists
+  "prose-ul:leading-8 prose-ol:leading-8",
+  "prose-li:my-1.5",
+
+  // Code
+  "prose-code:text-sm prose-code:font-medium",
+  "prose-code:before:content-none prose-code:after:content-none",
+
+  // Links
+  "prose-a:text-primary prose-a:underline-offset-4",
+  "hover:prose-a:underline",
+
+  // Tables
+  "prose-table:text-sm",
+  "prose-th:font-semibold",
+  "prose-td:align-top",
+
+  // ETC
+  "prose-img:rounded-lg prose-img:my-10",
+  "prose-hr:my-14",
+);

--- a/src/pages/posts/[...id].astro
+++ b/src/pages/posts/[...id].astro
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 
 import BaseLayout from "@/layouts/base-layout.astro";
 import { getCollection, render, type CollectionEntry } from "astro:content";
+import { proseClasses } from "@/lib/prose";
 
 export async function getStaticPaths() {
   const posts = await getCollection("posts");
@@ -44,7 +45,7 @@ const { Content } = await render(post);
         }
       </div>
     </header>
-    <div class="prose prose-neutral mt-6 max-w-none">
+    <div class={cn(proseClasses, "mt-6")}>
       <Content />
     </div>
   </article>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 @import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));


### PR DESCRIPTION
Extract prose styling into a reusable class list, enhancing maintainability and consistency across components. Update dependencies to include Tailwind CSS typography plugin.

## Screenshots

### Before

<img width="5088" height="3854" alt="image" src="https://github.com/user-attachments/assets/e8918919-0feb-482a-a944-b2e41e3a4f4b" />

### After

<img width="5088" height="3854" alt="image" src="https://github.com/user-attachments/assets/696ba4a7-e3d0-4a40-84ab-16443c616797" />