### PR TITLE
Fetch full git history for posts submodule during release

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Ensure full git history for posts
+        run: |
+          cd src/content/posts
+          git fetch --unshallow || git fetch --all
+
       - name: Generate posts metadata
         run: python3 scripts/generate-posts-meta.py
 


### PR DESCRIPTION
## Summary

This PR fixes an issue in the release workflow where post metadata was generated from an incomplete git history.

The blog content is stored in a git submodule (`src/content/posts`), and the metadata generation step relies on git history (e.g. commit dates, order, or revision data). However, when using `actions/checkout` with submodules, the submodule is checked out with a shallow history by default, which led to incorrect metadata.

## What changed

- After checking out the repository and its submodules, the workflow now explicitly fetches the full git history **only for the posts submodule**.
- The main repository remains shallow-cloned to keep CI fast.

### Before

<img width="2048" height="2368" alt="image" src="https://github.com/user-attachments/assets/78fde053-e8d7-4f88-8991-684bb4f829e1" />

## Why

- Post metadata depends on accurate git history.
- `actions/checkout` does not automatically unshallow submodules.
- Fetching full history for the entire repository would be unnecessary and slow.

This approach ensures correctness while keeping the release pipeline efficient.

## Scope

- CI/CD behavior only
- No application code or content changes