### PR TITLE
fix(ci): fix merge job credentials and add concurrency control

### DIFF
--- a/.github/workflows/synchronizer.yml
+++ b/.github/workflows/synchronizer.yml
@@ -4,6 +4,10 @@ on:
   repository_dispatch:
     types: ["content_updated"]
 
+concurrency:
+  group: content-sync
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -69,12 +73,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ssh-key: ${{ secrets.SYNC_CONTENTS_KEY }}
-          persist-credentials: false
           fetch-depth: 0
 
       - name: Fast-forward merge to main
         run: |
           git checkout main
           git reset --hard origin/main
+          git fetch origin automation/content-sync
           git merge --ff-only origin/automation/content-sync
           git push origin main


### PR DESCRIPTION
## Summary
- Remove `persist-credentials: false` from the `merge` job so the SSH key configured by `actions/checkout` survives for `git push origin main`
- Add explicit `git fetch origin automation/content-sync` before the `--ff-only` merge to guarantee the ref is local
- Add workflow-level `concurrency` group (`content-sync`, `cancel-in-progress: false`) to prevent overlapping `repository_dispatch` runs from racing each other
- Keep `git checkout main` / `git reset --hard origin/main` as defensive guards

## Test plan
- [ ] Trigger the synchronizer workflow via `repository_dispatch` with `content_updated` event type
- [ ] Verify the `merge` job completes successfully (previously failed on `git push` due to missing credentials)
- [ ] Verify concurrent dispatches are queued rather than running in parallel

https://claude.ai/code/session_0146omCdpeRtxFrc9ezLKUTm