### PR TITLE
fix(layout): remove inner scroll container on mobile

### DIFF
--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -21,12 +21,12 @@ const { title, description } = Astro.props;
     <meta property="og:description" content={description} />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   </head>
-  <body class="h-screen bg-accent overflow-hidden">
+  <body class="min-h-screen md:h-screen bg-accent md:overflow-hidden">
     <div class="m-2 rounded h-12 p-2">
       <HeaderIsland client:load />
     </div>
     <div
-      class="m-2 rounded h-[calc(100vh-var(--spacing)*18)] overflow-y-scroll"
+      class="m-2 rounded md:h-[calc(100vh-var(--spacing)*18)] md:overflow-y-scroll"
     >
       <slot />
     </div>


### PR DESCRIPTION
The base layout used a fixed-height inner container with
`overflow-y-scroll`, which kept a vertical scrollbar visible on
mobile even when content fit on the screen and trapped scroll inside
a nested element. On mobile we now let the body scroll naturally and
only apply the fixed-height scroll pane from the `md` breakpoint up.