### PR TITLE
feat(markdown): support GitHub-flavored alert blockquotes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@astrojs/react";
+import { remarkAlert } from "remark-github-blockquote-alert";
 
 export default defineConfig({
   site: "https://blog.seheon.kr",
@@ -9,4 +10,7 @@ export default defineConfig({
     plugins: [tailwindcss()],
   },
   integrations: [react()],
+  markdown: {
+    remarkPlugins: [remarkAlert],
+  },
 });

--- a/docs/decisions/ADR-001-github-flavored-markdown-alerts.md
+++ b/docs/decisions/ADR-001-github-flavored-markdown-alerts.md
@@ -1,0 +1,73 @@
+# ADR-001: GitHub-flavored Markdown alerts
+
+- Status: Accepted
+- Date: 2026-04-27
+
+## Context
+
+Authors want to use GitHub's alert syntax inside posts:
+
+```
+> [!NOTE]
+> ...
+
+> [!TIP]
+> ...
+
+> [!IMPORTANT]
+> ...
+
+> [!WARNING]
+> ...
+
+> [!CAUTION]
+> ...
+```
+
+The Astro markdown pipeline previously used defaults (`remark-parse`,
+`remark-gfm`, `remark-rehype`, `remark-smartypants`) with no custom plugins, so
+this syntax rendered as a plain blockquote with `[!TYPE]` shown as literal
+text. Posts are authored in `.md` (not `.mdx`) and sourced from the
+`blog-obsidian-vault` git submodule, so JSX/Astro components cannot be used
+inline.
+
+## Decision
+
+Add `remark-github-blockquote-alert` to `astro.config.mjs` under
+`markdown.remarkPlugins`. Style the generated `.markdown-alert*` classes in
+`src/styles/global.css` using Tailwind utilities via `@apply`, leveraging the
+existing `.dark` variant for theme support.
+
+## Alternatives considered
+
+- **`remark-directive` + custom handler.** More flexible, but introduces a
+  custom syntax (`:::note`) that does not match what authors paste from
+  GitHub. We do not need other directive types right now.
+- **Custom remark plugin.** Reimplementing what `remark-github-blockquote-alert`
+  already does is unnecessary maintenance.
+- **Migrate posts to `.mdx`.** Would let us write `<Alert />` JSX, but breaks
+  the obsidian-vault authoring flow (the submodule is plain markdown) and is
+  a much larger change.
+
+## Consequences
+
+Positive:
+
+- Authors can paste GitHub alert syntax directly into posts.
+- No change to the obsidian-vault authoring flow.
+- All styling lives in Tailwind tokens, so the design system stays consistent
+  and dark mode works automatically through the existing `.dark` variant.
+
+Trade-offs:
+
+- One additional remark plugin in the build pipeline (negligible perf impact).
+- The CSS class names (`.markdown-alert*`) are dictated by the plugin and not
+  prefixed under our design system; if we ever swap plugins we need to keep
+  the class names compatible or update the stylesheet.
+
+## Verification
+
+`pnpm test` runs `tests/remark-alert.test.ts`, which asserts the plugin emits
+`.markdown-alert-{note,tip,important,warning,caution}` for the five alert
+types and leaves plain blockquotes untouched. Visual verification is via
+`pnpm dev` against a fixture post.

--- a/package.json
+++ b/package.json
@@ -38,9 +38,14 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^4.0.16",
+    "rehype-stringify": "^10.0.1",
+    "remark-github-blockquote-alert": "^2.1.0",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
+    "unified": "^11.0.5",
     "vitest": "^4.0.16"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,18 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.16
         version: 4.0.16(vitest@4.0.16(@types/node@22.19.5)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      rehype-stringify:
+        specifier: ^10.0.1
+        version: 10.0.1
+      remark-github-blockquote-alert:
+        specifier: ^2.1.0
+        version: 2.1.0
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: ^11.1.2
+        version: 11.1.2
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -78,6 +90,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       vitest:
         specifier: ^4.0.16
         version: 4.0.16(@types/node@22.19.5)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
@@ -2159,6 +2174,10 @@ packages:
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-github-blockquote-alert@2.1.0:
+    resolution: {integrity: sha512-J392jmIP684d7iGsENN0uguL10IGbRdc8bTUSrd/jOLzdWkwg721Fj3JPQGN8tF6fTIrE5HHOIA3nBuwuaeuPQ==}
+    engines: {node: '>=16'}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -5003,6 +5022,10 @@ snapshots:
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
+
+  remark-github-blockquote-alert@2.1.0:
+    dependencies:
+      unist-util-visit: 5.0.0
 
   remark-parse@11.0.0:
     dependencies:

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -126,3 +126,59 @@
 img {
   filter: grayscale(100%);
 }
+
+@layer components {
+  .markdown-alert {
+    @apply my-6 rounded-md border-l-4 px-4 py-3;
+  }
+  .markdown-alert > p {
+    @apply my-2;
+  }
+  .markdown-alert > p:first-child {
+    @apply mt-0;
+  }
+  .markdown-alert > p:last-child {
+    @apply mb-0;
+  }
+  .markdown-alert-title {
+    @apply mb-2 flex items-center gap-2 font-semibold;
+  }
+  .markdown-alert-title svg {
+    @apply h-4 w-4 shrink-0;
+  }
+
+  .markdown-alert-note {
+    @apply border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/40;
+  }
+  .markdown-alert-note .markdown-alert-title {
+    @apply text-blue-700 dark:text-blue-300;
+  }
+
+  .markdown-alert-tip {
+    @apply border-green-500 bg-green-50 dark:border-green-400 dark:bg-green-950/40;
+  }
+  .markdown-alert-tip .markdown-alert-title {
+    @apply text-green-700 dark:text-green-300;
+  }
+
+  .markdown-alert-important {
+    @apply border-purple-500 bg-purple-50 dark:border-purple-400 dark:bg-purple-950/40;
+  }
+  .markdown-alert-important .markdown-alert-title {
+    @apply text-purple-700 dark:text-purple-300;
+  }
+
+  .markdown-alert-warning {
+    @apply border-amber-500 bg-amber-50 dark:border-amber-400 dark:bg-amber-950/40;
+  }
+  .markdown-alert-warning .markdown-alert-title {
+    @apply text-amber-700 dark:text-amber-300;
+  }
+
+  .markdown-alert-caution {
+    @apply border-red-500 bg-red-50 dark:border-red-400 dark:bg-red-950/40;
+  }
+  .markdown-alert-caution .markdown-alert-title {
+    @apply text-red-700 dark:text-red-300;
+  }
+}

--- a/tests/remark-alert.test.ts
+++ b/tests/remark-alert.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import rehypeStringify from "rehype-stringify";
+import { remarkAlert } from "remark-github-blockquote-alert";
+
+const sample = `
+> [!NOTE]
+> Highlights information that users should take into account, even when skimming.
+
+> [!TIP]
+> Optional information to help a user be more successful.
+
+> [!IMPORTANT]
+> Crucial information necessary for users to succeed.
+
+> [!WARNING]
+> Critical content demanding immediate user attention due to potential risks.
+
+> [!CAUTION]
+> Negative potential consequences of an action.
+`;
+
+async function render(md: string) {
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkAlert)
+    .use(remarkRehype)
+    .use(rehypeStringify)
+    .process(md);
+  return String(file);
+}
+
+describe("remark-github-blockquote-alert", () => {
+  it("renders all five GitHub alert types with the expected classes", async () => {
+    const html = await render(sample);
+    for (const type of ["note", "tip", "important", "warning", "caution"]) {
+      expect(html).toContain(`markdown-alert-${type}`);
+    }
+    expect(html).toContain("markdown-alert-title");
+  });
+
+  it("leaves plain blockquotes untouched", async () => {
+    const html = await render("> just a regular quote");
+    expect(html).not.toContain("markdown-alert");
+    expect(html).toContain("<blockquote>");
+  });
+});


### PR DESCRIPTION
Add `remark-github-blockquote-alert` to the Astro markdown pipeline so
posts can use `> [!NOTE]` / `[!TIP]` / `[!IMPORTANT]` / `[!WARNING]` /
`[!CAUTION]` syntax. Style the generated `.markdown-alert*` classes via
Tailwind `@apply` in `global.css`, with dark-mode variants. Document the
decision in ADR-001 and cover the plugin output with a vitest spec.