### PR TITLE
feat(post-detail): render Obsidian image embeds

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,8 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@astrojs/react";
 import { remarkAlert } from "remark-github-blockquote-alert";
 
+import remarkObsidianEmbed from "./src/lib/remark-obsidian-embed.ts";
+
 export default defineConfig({
   site: "https://blog.seheon.kr",
   base: "/",
@@ -14,6 +16,6 @@ export default defineConfig({
   },
   integrations: [react()],
   markdown: {
-    remarkPlugins: [remarkAlert],
+    remarkPlugins: [remarkObsidianEmbed, remarkAlert],
   },
 });

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.18",
     "@types/d3-force": "^3.0.10",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^22.10.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -44,6 +45,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0",
     "vitest": "^4.0.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "es-toolkit": "^1.43.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "sharp": "^0.34.5",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
@@ -47,5 +48,10 @@
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
     "vitest": "^4.0.16"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@types/d3-force':
         specifier: ^3.0.10
         version: 3.0.10
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.5
@@ -87,6 +90,9 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
       vitest:
         specifier: ^4.0.16
         version: 4.0.16(@types/node@22.19.5)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
@@ -2156,8 +2162,8 @@ packages:
   unist-util-visit-parents@6.0.2:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
 
-  unist-util-visit@5.0.0:
-    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   unstorage@1.17.3:
     resolution: {integrity: sha512-i+JYyy0DoKmQ3FximTHbGadmIYb8JEpq7lxUjnjeB702bCPum0vzo6oy5Mfu0lpqISw7hCyMW2yj4nWC8bqJ3Q==}
@@ -2576,7 +2582,7 @@ snapshots:
       smol-toml: 1.6.0
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
       vfile: 6.0.3
     transitivePeerDependencies:
@@ -3466,7 +3472,7 @@ snapshots:
       tsconfck: 3.1.6(typescript@5.9.3)
       ultrahtml: 1.6.0
       unifont: 0.7.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       unstorage: 1.17.3
       vfile: 6.0.3
       vite: 6.4.1(@types/node@22.19.5)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
@@ -3878,7 +3884,7 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       parse5: 7.3.0
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
       web-namespaces: 2.0.1
       zwitch: 2.0.4
@@ -4084,7 +4090,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -4181,7 +4187,7 @@ snapshots:
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
 
   mdast-util-to-markdown@2.1.2:
@@ -4193,7 +4199,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
   mdast-util-to-string@4.0.0:
@@ -4569,7 +4575,7 @@ snapshots:
 
   remark-github-blockquote-alert@2.1.0:
     dependencies:
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   remark-parse@11.0.0:
     dependencies:
@@ -4593,7 +4599,7 @@ snapshots:
       retext: 9.0.0
       retext-smartypants: 6.2.0
       unified: 11.0.5
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   remark-stringify@11.0.0:
     dependencies:
@@ -4619,7 +4625,7 @@ snapshots:
     dependencies:
       '@types/nlcst': 2.0.3
       nlcst-to-string: 4.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   retext-stringify@4.0.0:
     dependencies:
@@ -4866,7 +4872,7 @@ snapshots:
   unist-util-remove-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   unist-util-stringify-position@4.0.0:
     dependencies:
@@ -4881,7 +4887,7 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
 
-  unist-util-visit@5.0.0:
+  unist-util-visit@5.1.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -2855,8 +2858,7 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@img/colour@1.0.0':
-    optional: true
+  '@img/colour@1.0.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -4715,7 +4717,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shiki@3.21.0:
     dependencies:

--- a/src/lib/remark-obsidian-embed.ts
+++ b/src/lib/remark-obsidian-embed.ts
@@ -1,0 +1,125 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { Image, Root, RootContent, Text } from "mdast";
+import type { Plugin } from "unified";
+import { visit, SKIP } from "unist-util-visit";
+
+const POSTS_ROOT = path.resolve("src/content/posts");
+const RESOURCES_DIRNAME = "_resources";
+
+// Obsidian image embed: ![[file.ext]] / ![[file.ext|alt]] / ![[file.ext|WIDTH]]
+// / ![[file.ext|WIDTHxHEIGHT]] / ![[file.ext|alt|WIDTHxHEIGHT]]. The pipe
+// segments after the filename are interpreted as size when they look like
+// `\d+` or `\d+x\d+`, otherwise as alt text. This matches Obsidian's behavior
+// described in https://obsidian.md/help/embeds.
+const EMBED_RE = /!\[\[([^\]\n|]+)((?:\|[^\]\n|]*)*)\]\]/g;
+const SIZE_RE = /^(\d+)(?:x(\d+))?$/;
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|avif|svg|bmp|ico)$/i;
+
+interface EmbedSpec {
+  alt: string;
+  width?: number;
+  height?: number;
+}
+
+function parseSpec(filename: string, suffix: string): EmbedSpec {
+  const segments = suffix
+    .split("|")
+    .slice(1) // leading empty segment from the split on "|first|second"
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  let alt = filename;
+  let width: number | undefined;
+  let height: number | undefined;
+
+  for (const seg of segments) {
+    const sizeMatch = seg.match(SIZE_RE);
+    if (sizeMatch) {
+      width = Number(sizeMatch[1]);
+      height = sizeMatch[2] ? Number(sizeMatch[2]) : undefined;
+    } else {
+      alt = seg;
+    }
+  }
+  return { alt, width, height };
+}
+
+function toRelativeUrl(fromDir: string, filename: string): string {
+  const target = path.join(POSTS_ROOT, RESOURCES_DIRNAME, filename);
+  let rel = path.relative(fromDir, target).replace(/\\/g, "/");
+  if (!rel.startsWith(".")) rel = "./" + rel;
+  return rel;
+}
+
+function buildImageNode(url: string, spec: EmbedSpec): Image {
+  const node: Image = { type: "image", url, alt: spec.alt };
+  const props: Record<string, number> = {};
+  if (spec.width != null) props.width = spec.width;
+  if (spec.height != null) props.height = spec.height;
+  if (Object.keys(props).length > 0) {
+    node.data = { hProperties: props };
+  }
+  return node;
+}
+
+function resolveFileDir(file: { path?: string; history?: string[] }): string | null {
+  const filePath = file.path ?? file.history?.[file.history.length - 1];
+  if (!filePath) return null;
+  const resolved = filePath.startsWith("file://")
+    ? fileURLToPath(filePath)
+    : path.resolve(filePath);
+  return path.dirname(resolved);
+}
+
+const remarkObsidianEmbed: Plugin<[], Root> = () => {
+  return (tree, file) => {
+    const fileDir = resolveFileDir(file);
+    if (!fileDir) return;
+
+    visit(tree, "text", (node: Text, index, parent) => {
+      if (parent == null || index == null) return;
+      const value = node.value;
+      if (!value.includes("![[")) return;
+
+      const replacements = buildReplacements(value, fileDir);
+      if (replacements == null) return;
+
+      parent.children.splice(index, 1, ...replacements);
+      return [SKIP, index + replacements.length];
+    });
+  };
+};
+
+function buildReplacements(
+  value: string,
+  fileDir: string,
+): RootContent[] | null {
+  const out: RootContent[] = [];
+  let lastIndex = 0;
+  let matched = false;
+  EMBED_RE.lastIndex = 0;
+  for (const match of value.matchAll(EMBED_RE)) {
+    const filename = match[1].trim();
+    if (!IMAGE_EXT_RE.test(filename)) continue; // leave non-image embeds alone
+
+    matched = true;
+    const start = match.index ?? 0;
+    if (start > lastIndex) {
+      out.push({ type: "text", value: value.slice(lastIndex, start) });
+    }
+    const spec = parseSpec(filename, match[2] ?? "");
+    const url = toRelativeUrl(fileDir, filename);
+    out.push(buildImageNode(url, spec));
+    lastIndex = start + match[0].length;
+  }
+  if (!matched) return null;
+  if (lastIndex < value.length) {
+    out.push({ type: "text", value: value.slice(lastIndex) });
+  }
+  return out;
+}
+
+export default remarkObsidianEmbed;
+export { buildReplacements, parseSpec, toRelativeUrl };

--- a/tests/remark-obsidian-embed.test.ts
+++ b/tests/remark-obsidian-embed.test.ts
@@ -1,0 +1,76 @@
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import rehypeStringify from "rehype-stringify";
+
+import remarkObsidianEmbed from "../src/lib/remark-obsidian-embed";
+
+const POST_PATH = path.resolve("src/content/posts/agentic-ai-stack.md");
+const NESTED_POST_PATH = path.resolve("src/content/posts/Algorithms/segment-tree.md");
+
+async function render(md: string, postPath = POST_PATH) {
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkObsidianEmbed)
+    .use(remarkRehype)
+    .use(rehypeStringify)
+    .process({ value: md, path: postPath });
+  return String(file);
+}
+
+describe("remark-obsidian-embed", () => {
+  it("converts a basic image embed to an <img> with a relative URL", async () => {
+    const html = await render("![[diagram.svg]]");
+    expect(html).toContain('src="./_resources/diagram.svg"');
+    expect(html).toContain('alt="diagram.svg"');
+  });
+
+  it("encodes width-only size spec as a width attribute", async () => {
+    const html = await render("![[diagram.svg|650]]");
+    expect(html).toContain('width="650"');
+    expect(html).not.toContain("height");
+  });
+
+  it("encodes width and height", async () => {
+    const html = await render("![[diagram.svg|640x480]]");
+    expect(html).toContain('width="640"');
+    expect(html).toContain('height="480"');
+  });
+
+  it("uses the non-numeric pipe segment as alt text", async () => {
+    const html = await render("![[diagram.svg|Architecture overview]]");
+    expect(html).toContain('alt="Architecture overview"');
+  });
+
+  it("supports alt text combined with size", async () => {
+    const html = await render("![[diagram.svg|Architecture|800x600]]");
+    expect(html).toContain('alt="Architecture"');
+    expect(html).toContain('width="800"');
+    expect(html).toContain('height="600"');
+  });
+
+  it("computes a deeper relative path for posts in subdirectories", async () => {
+    const html = await render("![[diagram.svg]]", NESTED_POST_PATH);
+    expect(html).toContain('src="../_resources/diagram.svg"');
+  });
+
+  it("leaves non-image embeds untouched", async () => {
+    const html = await render("![[some-note]]");
+    expect(html).toContain("![[some-note]]");
+    expect(html).not.toContain("<img");
+  });
+
+  it("preserves surrounding text in the same paragraph", async () => {
+    const html = await render("before ![[diagram.svg]] after");
+    expect(html).toMatch(/before\s*<img[^>]+>\s*after/);
+  });
+
+  it("ignores plain (non-embed) wikilinks", async () => {
+    const html = await render("see [[Other Note]]");
+    expect(html).not.toContain("<img");
+    expect(html).toContain("[[Other Note]]");
+  });
+});


### PR DESCRIPTION
Posts authored in Obsidian use the wikilink embed syntax
`![[file.ext|widthxheight]]` to reference images stored in the
shared `_resources/` folder. Astro's markdown pipeline doesn't
recognize this syntax, so those embeds rendered as raw text on
article detail pages.

Add a remark plugin that rewrites image embeds into mdast image
nodes with a relative URL pointing into `_resources/`. Astro's
asset pipeline then processes them like any other relative image,
emitting hashed `<img>` tags with optional width/height attributes
preserved from the Obsidian size spec.