### PR TITLE
test(content): seed fixture posts so suite runs without the private vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ The blog is designed to be fast, SEO-friendly, and easy to maintain over the lon
 
 This keeps the site lightweight while still supporting rich visualizations.
 
+## Development
+
+```sh
+pnpm install
+pnpm dev        # local dev server on :3000
+pnpm lint       # astro check
+pnpm test       # vitest run
+pnpm coverage   # vitest run --coverage
+```
+
+### Tests without the content vault
+
+The post content lives in the private [blog-obsidian-vault](https://github.com/seheon99/blog-obsidian-vault) submodule mounted at `src/content/posts/`. Contributors and CI runs without vault access don't have any posts on disk, which would leave `getCollection("posts")` empty and break every test that renders a page.
+
+To keep the suite self-contained, `tests/global-setup.ts` seeds the markdown files under `tests/fixtures/posts/` into `src/content/posts/` only when that directory has no posts of its own, runs `astro sync` to build the data store, and removes the seeded files on teardown. The fixtures are deliberately minimal — just enough to satisfy the page-rendering tests (one post per primary tag, one post with `h2`/`h3` headings for the TOC tests).
+
 ## Notes
 
 This repository replaces a legacy [blog-nextjs](https://github.com/seheon99/blog-nextjs). The rewrite was intentional to reduce runtime complexity, improve performance and SEO, and adopt a static-first architecture better suited for long-form content

--- a/tests/fixtures/posts/algorithm-binary-search.md
+++ b/tests/fixtures/posts/algorithm-binary-search.md
@@ -1,0 +1,9 @@
+---
+title: "Binary search invariants"
+description: "Loop invariants that keep binary search correct on every iteration"
+createdAt: 2023-11-04
+tags:
+  - Algorithm
+---
+
+The classic binary-search loop maintains two invariants: the target, if present, lies in the half-open interval `[lo, hi)`, and `lo <= hi` at every step.

--- a/tests/fixtures/posts/javascript-symbol.md
+++ b/tests/fixtures/posts/javascript-symbol.md
@@ -1,0 +1,21 @@
+---
+title: "JavaScript Symbol"
+description: "Notes on the Symbol primitive in JavaScript"
+createdAt: 2024-03-15
+tags:
+  - JavaScript
+---
+
+A Symbol is a unique and immutable primitive value introduced in ES2015.
+
+## Creating Symbols
+
+You create a Symbol by calling the Symbol() function. Each call returns a brand-new value.
+
+### Symbol descriptions
+
+The optional description argument is purely diagnostic. Two Symbols with the same description are still distinct.
+
+## Well-known Symbols
+
+The language defines a handful of well-known Symbols, exposed as static properties on Symbol itself.

--- a/tests/fixtures/posts/typescript-narrowing.md
+++ b/tests/fixtures/posts/typescript-narrowing.md
@@ -1,0 +1,9 @@
+---
+title: "TypeScript narrowing"
+description: "How TypeScript narrows union types in control-flow positions"
+createdAt: 2024-02-10
+tags:
+  - TypeScript
+---
+
+TypeScript narrows union types based on type guards in conditional branches. The compiler tracks the narrowed type through each branch.

--- a/tests/fixtures/posts/web-platform-streams.md
+++ b/tests/fixtures/posts/web-platform-streams.md
@@ -1,0 +1,10 @@
+---
+title: "Web Platform streams"
+description: "ReadableStream and WritableStream on the modern web platform"
+createdAt: 2024-01-20
+tags:
+  - JavaScript
+  - WebPlatform
+---
+
+Streams let you process data chunk-by-chunk without buffering the full payload.

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,65 @@
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  readdirSync,
+  unlinkSync,
+} from "node:fs";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const FIXTURES_DIR = path.join(REPO_ROOT, "tests/fixtures/posts");
+const POSTS_DIR = path.join(REPO_ROOT, "src/content/posts");
+// `astro sync --mode test` lands data-store.json in cacheDir
+// (node_modules/.astro). The container API spun up by Vitest reads from
+// dotAstroDir (.astro). Copy the produced store across so getCollection()
+// resolves under both layouts.
+const SYNC_OUTPUT = path.join(REPO_ROOT, "node_modules/.astro/data-store.json");
+const RUNTIME_STORE = path.join(REPO_ROOT, ".astro/data-store.json");
+
+function listMarkdown(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((f) => f.endsWith(".md"));
+}
+
+// `src/content/posts` is a private submodule. When it isn't checked out
+// (CI without submodules, fresh clones, contributors without vault access),
+// the directory is empty and content-collection-driven tests have nothing
+// to render. Seed fixture markdown into that path for the test run only.
+export default function setup() {
+  const seeded: string[] = [];
+  let copiedStore = false;
+
+  if (listMarkdown(POSTS_DIR).length === 0) {
+    for (const file of listMarkdown(FIXTURES_DIR)) {
+      const dest = path.join(POSTS_DIR, file);
+      copyFileSync(path.join(FIXTURES_DIR, file), dest);
+      seeded.push(dest);
+    }
+  }
+
+  if (seeded.length > 0) {
+    execFileSync("npx", ["astro", "sync"], { cwd: REPO_ROOT, stdio: "inherit" });
+    if (existsSync(SYNC_OUTPUT)) {
+      copyFileSync(SYNC_OUTPUT, RUNTIME_STORE);
+      copiedStore = true;
+    }
+  }
+
+  return () => {
+    for (const file of seeded) {
+      try {
+        unlinkSync(file);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    if (copiedStore) {
+      try {
+        unlinkSync(RUNTIME_STORE);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,5 +13,6 @@ export default getViteConfig({
   // astro's getViteConfig type doesn't surface the test field.
   test: {
     fileParallelism: false,
+    globalSetup: ["./tests/global-setup.ts"],
   },
 });


### PR DESCRIPTION
`getCollection("posts")` returned an empty array whenever the
blog-obsidian-vault submodule isn't checked out, which left every
content-driven test rendering a page with zero posts. That caused three
assertion failures in `tests/index-graph-pane.test.ts` (active tag chip,
filtered row count, featured panel) and a hard suite failure in
`tests/post-detail.test.ts` from `RenderUndefinedEntryError`.

Add a vitest global setup that, only when `src/content/posts/` is empty,
copies the markdown fixtures under `tests/fixtures/posts/` into it, runs
`astro sync` so the content layer's data-store is populated, and tears
the seeded files down afterwards. The data-store also has to be mirrored
into `.astro/` because `astro sync` writes it to `node_modules/.astro/`
while the container API spun up in tests reads from the dotAstroDir.