### PR TITLE
feat(markdown): render LaTeX math via remark-math + rehype-katex

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,8 @@ import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@astrojs/react";
 import { remarkAlert } from "remark-github-blockquote-alert";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
 
 import remarkObsidianEmbed from "./src/lib/remark-obsidian-embed.ts";
 import remarkMermaid from "./src/lib/remark-mermaid.ts";
@@ -17,6 +19,7 @@ export default defineConfig({
   },
   integrations: [react()],
   markdown: {
-    remarkPlugins: [remarkObsidianEmbed, remarkAlert, remarkMermaid],
+    remarkPlugins: [remarkObsidianEmbed, remarkAlert, remarkMermaid, remarkMath],
+    rehypePlugins: [rehypeKatex],
   },
 });

--- a/docs/decisions/ADR-006-katex-math-rendering.md
+++ b/docs/decisions/ADR-006-katex-math-rendering.md
@@ -1,0 +1,51 @@
+# ADR-006: KaTeX math rendering
+
+- Status: Accepted
+- Date: 2026-05-03
+
+## Context
+
+Authors want to write inline and block math inside posts using the
+dollar-sign LaTeX syntax that Obsidian also uses:
+
+```
+The lookup is $O(n)$ in the worst case.
+
+$$
+H(p, q) = -\sum_{i} p_i \log q_i
+$$
+```
+
+The Astro markdown pipeline did not understand this syntax, so `$O(n)$`
+rendered as the literal characters `$O(n)$`. Posts are authored in `.md`
+(not `.mdx`) inside the `blog-obsidian-vault` git submodule, so JSX
+components cannot be embedded inline — the fix has to live in the remark
+/ rehype pipeline.
+
+## Decision
+
+Add `remark-math` and `rehype-katex` to `astro.config.mjs`:
+
+- `remark-math` recognizes `$…$` (inline) and `$$…$$` (block) as math
+  nodes in the mdast.
+- `rehype-katex` renders those nodes to KaTeX HTML at build time, so the
+  rendered pages ship as static HTML with no client-side math runtime.
+
+Load `katex/dist/katex.min.css` from the base layout so the rendered HTML
+gets the right glyph metrics. Astro/Vite bundles the stylesheet with the
+rest of the site CSS — no external CDN dependency.
+
+KaTeX self-hosts its own fonts inside the package; they are emitted to
+`/dist/_astro/` along with the rest of the build assets.
+
+## Alternatives considered
+
+- **MathJax via `rehype-mathjax`.** Comparable feature coverage but
+  larger payload (the SVG output is heavier than KaTeX's HTML+CSS) and
+  slower at build time. KaTeX covers the LaTeX subset this blog needs.
+- **Client-side rendering with `katex/contrib/auto-render`.** Would push
+  parsing to the browser and add a flash of unrendered `$…$` text on
+  first paint. Build-time rendering keeps the page static.
+- **Custom remark plugin.** Reimplementing dollar-delimited math parsing
+  is unnecessary maintenance — `remark-math` is the canonical plugin in
+  the unified ecosystem and is what Obsidian-flavored math expects.

--- a/docs/v2-redesign-progress.md
+++ b/docs/v2-redesign-progress.md
@@ -42,6 +42,7 @@ Update this file whenever a phase ships, splits, or changes scope.
 - [ADR-003](decisions/ADR-003-graph-view-react-island.md) — graph view re-introduces a React island; ADR-002's load-bearing-reason bar is met (simulation lifecycle, ResizeObserver, drag handlers, future reuse in phases 6–7).
 - [ADR-004](decisions/ADR-004-d3-force-graph-rendering.md) — `d3-force` + hand-rolled SVG over `react-force-graph` / `cytoscape` / `sigma`.
 - [ADR-005](decisions/ADR-005-wikilink-edges-obsidian-workflow.md) — graph edges come from `[[wikilinks]]` so the published graph mirrors the Obsidian vault graph.
+- [ADR-006](decisions/ADR-006-katex-math-rendering.md) — dollar-delimited math (`$…$`, `$$…$$`) renders via `remark-math` + `rehype-katex` at build time.
 
 ## Update protocol
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,12 @@
     "clsx": "^2.1.1",
     "d3-force": "^3.0.0",
     "es-toolkit": "^1.43.0",
+    "katex": "^0.16.45",
     "mermaid": "^11.14.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "rehype-katex": "^7.0.1",
+    "remark-math": "^6.0.0",
     "sharp": "^0.34.5",
     "tailwind-merge": "^3.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       es-toolkit:
         specifier: ^1.43.0
         version: 1.43.0
+      katex:
+        specifier: ^0.16.45
+        version: 0.16.45
       mermaid:
         specifier: ^11.14.0
         version: 11.14.0
@@ -35,6 +38,12 @@ importers:
       react-dom:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
+      rehype-katex:
+        specifier: ^7.0.1
+        version: 7.0.1
+      remark-math:
+        specifier: ^6.0.0
+        version: 6.0.0
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -1005,6 +1014,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -1705,6 +1717,12 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  hast-util-from-dom@5.0.1:
+    resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
+
+  hast-util-from-html-isomorphic@2.0.0:
+    resolution: {integrity: sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==}
+
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
 
@@ -2002,6 +2020,9 @@ packages:
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
+  mdast-util-math@3.0.0:
+    resolution: {integrity: sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -2050,6 +2071,9 @@ packages:
 
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -2280,6 +2304,9 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
+  rehype-katex@7.0.1:
+    resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
+
   rehype-parse@9.0.1:
     resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
 
@@ -2298,6 +2325,9 @@ packages:
   remark-github-blockquote-alert@2.1.0:
     resolution: {integrity: sha512-J392jmIP684d7iGsENN0uguL10IGbRdc8bTUSrd/jOLzdWkwg721Fj3JPQGN8tF6fTIrE5HHOIA3nBuwuaeuPQ==}
     engines: {node: '>=16'}
+
+  remark-math@6.0.0:
+    resolution: {integrity: sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -3770,6 +3800,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/katex@0.16.8': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -4614,6 +4646,19 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  hast-util-from-dom@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hastscript: 9.0.1
+      web-namespaces: 2.0.1
+
+  hast-util-from-html-isomorphic@2.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-dom: 5.0.1
+      hast-util-from-html: 2.0.3
+      unist-util-remove-position: 5.0.0
+
   hast-util-from-html@2.0.3:
     dependencies:
       '@types/hast': 3.0.4
@@ -4973,6 +5018,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-math@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      longest-streak: 3.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      unist-util-remove-position: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -5111,6 +5168,16 @@ snapshots:
       micromark-extension-gfm-tagfilter: 2.0.0
       micromark-extension-gfm-task-list-item: 2.1.0
       micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.45
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -5383,6 +5450,16 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  rehype-katex@7.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/katex': 0.16.8
+      hast-util-from-html-isomorphic: 2.0.0
+      hast-util-to-text: 4.0.2
+      katex: 0.16.45
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+
   rehype-parse@9.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -5422,6 +5499,15 @@ snapshots:
   remark-github-blockquote-alert@2.1.0:
     dependencies:
       unist-util-visit: 5.1.0
+
+  remark-math@6.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-math: 3.0.0
+      micromark-extension-math: 3.1.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remark-parse@11.0.0:
     dependencies:

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -1,6 +1,7 @@
 ---
 import Header from "@/components/ui/header.astro";
 import "@/styles/global.css";
+import "katex/dist/katex.min.css";
 
 interface Props {
   title: string;

--- a/tests/remark-math.test.ts
+++ b/tests/remark-math.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkMath from "remark-math";
+import remarkRehype from "remark-rehype";
+import rehypeKatex from "rehype-katex";
+import rehypeStringify from "rehype-stringify";
+
+async function render(md: string) {
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkMath)
+    .use(remarkRehype)
+    .use(rehypeKatex)
+    .use(rehypeStringify)
+    .process(md);
+  return String(file);
+}
+
+describe("remark-math + rehype-katex", () => {
+  it("renders inline $…$ math as a KaTeX inline span", async () => {
+    const html = await render("The lookup is $O(n)$ in the worst case.");
+    expect(html).toContain('class="katex"');
+    expect(html).not.toContain("$O(n)$");
+  });
+
+  it("renders block $$…$$ math as a KaTeX display span", async () => {
+    const html = await render("$$\nH(p, q) = -\\sum_{i} p_i \\log q_i\n$$");
+    expect(html).toContain("katex-display");
+    expect(html).not.toContain("$$");
+  });
+
+  it("leaves non-math dollar signs alone in regular prose", async () => {
+    const html = await render("Costs about $5 to run.");
+    expect(html).not.toContain('class="katex"');
+    expect(html).toContain("$5");
+  });
+});


### PR DESCRIPTION
Posts authored in the Obsidian vault use dollar-delimited math
(`$O(n)$`, `$$…$$`), but the markdown pipeline treated those as
literal text. Wire `remark-math` into `markdown.remarkPlugins` and
`rehype-katex` into `markdown.rehypePlugins` so math nodes render to
KaTeX HTML at build time. Import `katex/dist/katex.min.css` from
`base-layout.astro` so glyph metrics and fonts ship with the rest of
the site CSS — no client-side math runtime, no CDN. Recorded as
ADR-006.