### PR TITLE
Treat wikilink edges as undirected in getBacklinks

### DIFF
--- a/src/lib/post-graph.ts
+++ b/src/lib/post-graph.ts
@@ -125,11 +125,13 @@ export function getBacklinks(
   for (const { fromId, toId } of iterateRefs(posts, idSet, titleMap, {
     warnUnresolved: false,
   })) {
-    if (toId !== targetId) continue;
-    if (fromId === targetId) continue;
-    if (seen.has(fromId)) continue;
-    seen.add(fromId);
-    const node = nodesById.get(fromId);
+    const otherId =
+      fromId === targetId ? toId : toId === targetId ? fromId : null;
+    if (otherId === null) continue;
+    if (otherId === targetId) continue;
+    if (seen.has(otherId)) continue;
+    seen.add(otherId);
+    const node = nodesById.get(otherId);
     if (node) result.push(node);
   }
   return result;

--- a/tests/post-graph.test.ts
+++ b/tests/post-graph.test.ts
@@ -150,13 +150,25 @@ describe("getBacklinks", () => {
     expect(result.map((n) => n.id)).toEqual(["a"]);
   });
 
-  it("only includes incoming references (the target's outgoing refs do not count)", () => {
-    // a → b; we look up backlinks for a, only b would qualify if it linked back.
+  it("returns a post the target itself references (outgoing edges count too)", () => {
+    // a → b; backlinks for a should include b — wikilink edges are undirected,
+    // matching the graph view in `buildPostGraph`.
     const result = getBacklinks(
       [post("a", "Alpha", "see [[Beta]]"), post("b", "Beta")],
       "a",
     );
-    expect(result).toEqual([]);
+    expect(result.map((n) => n.id)).toEqual(["b"]);
+  });
+
+  it("dedupes when posts reference each other in both directions", () => {
+    const result = getBacklinks(
+      [
+        post("a", "Alpha", "see [[Beta]]"),
+        post("b", "Beta", "back to [[Alpha]]"),
+      ],
+      "a",
+    );
+    expect(result.map((n) => n.id)).toEqual(["b"]);
   });
 
   it("excludes the target post itself even if its body wikilinks to itself", () => {


### PR DESCRIPTION
## Summary
Changed `getBacklinks` to treat wikilink references as undirected edges, so that both incoming and outgoing references from the target post are included in backlinks results.

## Key Changes
- Modified `getBacklinks` logic to include posts that the target references (outgoing edges), not just posts that reference the target (incoming edges)
- Implemented deduplication to handle cases where two posts reference each other bidirectionally
- Updated test expectations to reflect the new behavior where `a → b` means `b` is a backlink for `a`

## Implementation Details
The core change replaces the directional check `if (toId !== targetId) continue;` with logic that treats edges as undirected:
- For each reference edge, determine which end is the target and which is the "other" post
- Include the "other" post in results regardless of reference direction
- Maintain deduplication via the `seen` Set to avoid duplicates when posts reference each other in both directions

This aligns `getBacklinks` behavior with how the graph view in `buildPostGraph` treats wikilink edges as undirected.

https://claude.ai/code/session_01Xn6focodHSYzvhchFcAyPW