### PR TITLE
Introduce `type`/`updatedAt` frontmatter, show wiki updated date, and ADR for collection decision

### DIFF
--- a/docs/decisions/ADR-001-wiki-vs-article-separation.md
+++ b/docs/decisions/ADR-001-wiki-vs-article-separation.md
@@ -1,0 +1,92 @@
+# ADR-001: Wiki vs Article Separation
+
+- **Date:** 2026-05-05
+- **Status:** Accepted
+- **Repos:** [blog-obsidian-vault](https://github.com/seheon99/blog-obsidian-vault), [blog](https://github.com/seheon99/blog)
+
+## Context
+
+We needed to decide whether to separate content into two Astro collections:
+
+- `wiki`: living reference notes
+- `article`: timestamped narrative posts
+
+The distinction is behavioral and editorial:
+
+| Dimension | Wiki | Article |
+|---|---|---|
+| Purpose | Knowledge accumulation (reference) | Argument/narrative delivery |
+| Temporality | Continuously updated | Fixed at publish time |
+| Primary reader | Self-included | External audience |
+| Typical examples | Tech notes, glossaries | Retrospectives, tutorials, opinions |
+
+## Analysis
+
+### Vault-level observations
+
+From content in `blog-obsidian-vault`, both types already exist under one schema:
+
+- **Wiki-like** notes where `createdAt` has little meaning (for example concept/reference pages).
+- **Article-like** posts with a narrative arc where publish date matters.
+
+At the time of analysis, the default article template did not include either `type` or `updatedAt` fields.
+
+### Blog codebase constraints
+
+A two-collection split would require broad rewrites:
+
+1. `remark-obsidian-wikilink.ts` is built around a single posts root and `/posts/...` URLs.
+2. `post-graph.ts` expects one flat post array and a single URL namespace.
+3. Existing synchronization setup is oriented around a single content source.
+4. Cross-linking already exists between article-like and wiki-like pages; splitting collections would complicate wikilink resolution and graph cohesion.
+
+## Decision
+
+Use **one collection** (`posts`) and add a frontmatter discriminator:
+
+- `type: "article" | "wiki"` (default to `wiki`)
+- `updatedAt?: Date` (primarily for wiki pages)
+
+Do **not** split into separate Astro collections.
+
+## Implementation summary
+
+### Content schema
+
+In `src/content/config.ts`:
+
+- Add `type: z.enum(["wiki", "article"]).default("wiki")`
+- Add `updatedAt: z.coerce.date().optional()`
+
+### Index behavior (`src/pages/index.astro`)
+
+- Build graph from all posts (articles + wikis).
+- In **list view**, show only article posts.
+- Keep tag filtering behavior.
+- Keep graph view inclusive of all post types.
+
+### Post detail behavior (`src/pages/posts/[...id].astro`)
+
+- For wiki posts with `updatedAt`, display an updated date label.
+- Otherwise display `createdAt`.
+
+## Consequences
+
+### Positive
+
+- Minimal code change with low migration risk.
+- Preserves existing `/posts/...` routes.
+- Keeps wikilink resolution and graph connectivity intact.
+- Enables UI separation by content intent without structural split.
+
+### Trade-offs
+
+- URL space remains unified (`/posts/...`) instead of `/wiki/...` and `/articles/...`.
+- Type-specific behavior now depends on frontmatter correctness.
+
+## Follow-up
+
+1. Ensure source templates include `type` consistently.
+2. Add a dedicated wiki template with `updatedAt` guidance.
+3. Backfill `type` in existing content where appropriate.
+4. Add content-level linting to enforce `type` for new posts.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -11,7 +11,9 @@ const posts = defineCollection({
     .object({
       title: z.string(),
       description: z.string(),
+      type: z.enum(["wiki", "article"]).default("wiki"),
       createdAt: z.coerce.date(),
+      updatedAt: z.coerce.date().optional(),
       // Posts authored in Obsidian historically used `topics`; site code
       // standardizes on `tags`. Accept both, normalize via transform below.
       tags: z.array(z.string()).optional(),

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,9 +15,18 @@ const activeTag = Astro.url.searchParams.get("tag");
 const allPosts = await getCollection("posts");
 const graph = buildPostGraph(allPosts);
 
-const sorted = [...allPosts].sort(
-  (a, b) => b.data.createdAt.getTime() - a.data.createdAt.getTime(),
-);
+const compareByCreatedAtDesc = (
+  a: (typeof allPosts)[number],
+  b: (typeof allPosts)[number],
+) => b.data.createdAt.getTime() - a.data.createdAt.getTime();
+
+const articles = allPosts
+  .filter((post) => post.data.type === "article")
+  .sort(compareByCreatedAtDesc);
+
+const wikis = allPosts
+  .filter((post) => post.data.type === "wiki")
+  .sort(compareByCreatedAtDesc);
 
 // Stable, alphabetical list of every tag in use.
 const tagSet = new Set<string>();
@@ -26,11 +35,11 @@ for (const p of allPosts) {
 }
 const allTags = [...tagSet].sort((a, b) => a.localeCompare(b));
 
-const filteredSorted = activeTag
-  ? sorted.filter((p) => p.data.tags?.includes(activeTag))
-  : sorted;
+const filterByTag = (post: (typeof allPosts)[number]) =>
+  !activeTag || post.data.tags?.includes(activeTag);
 
-const posts = filteredSorted.map((post) => ({
+const filteredArticles = articles.filter(filterByTag);
+const listPosts = filteredArticles.map((post) => ({
   href: `/posts/${post.id}`,
   title: post.data.title,
   description: post.data.description,
@@ -39,7 +48,7 @@ const posts = filteredSorted.map((post) => ({
   primaryTag: post.data.tags?.[0],
 }));
 
-const featured = sorted[0];
+const featured = articles[0] ?? wikis[0];
 ---
 
 <BaseLayout title="seheon blog" description="글 목록">
@@ -51,7 +60,7 @@ const featured = sorted[0];
         글
       </h1>
       <p class="mt-2 text-sm text-fg-3">
-        {posts.length}개의 글
+        {listPosts.length}개의 글
       </p>
       <div class="mt-6 mb-10">
         <TagChipsRow
@@ -61,7 +70,7 @@ const featured = sorted[0];
         />
       </div>
       <div class="flex flex-col">
-        {posts.map((post) => <WritingRow {...post} />)}
+        {listPosts.map((post) => <WritingRow {...post} />)}
       </div>
     </main>
   </section>

--- a/src/pages/posts/[...id].astro
+++ b/src/pages/posts/[...id].astro
@@ -44,6 +44,10 @@ const words = wordCount(body);
 const primaryTag = post.data.tags?.[0];
 
 const dateLabel = formatPostDate(post.data.createdAt)?.toUpperCase();
+const updatedDateLabel = post.data.updatedAt
+  ? formatPostDate(post.data.updatedAt)?.toUpperCase()
+  : null;
+const shouldShowUpdatedDate = post.data.type === "wiki" && !!post.data.updatedAt;
 
 const allPosts = await getCollection("posts");
 const graph = buildPostGraph(allPosts);
@@ -82,9 +86,17 @@ const backlinks = getBacklinks(allPosts, post.id);
           <div
             class="mt-6 font-mono text-[11px] uppercase tracking-[0.04em] text-fg-3"
           >
-            <time datetime={post.data.createdAt.toISOString()}>
-              {dateLabel}
-            </time>
+            {
+              shouldShowUpdatedDate ? (
+                <time datetime={post.data.updatedAt!.toISOString()}>
+                  UPDATED {updatedDateLabel}
+                </time>
+              ) : (
+                <time datetime={post.data.createdAt.toISOString()}>
+                  {dateLabel}
+                </time>
+              )
+            }
             <span class="px-1.5">·</span>
             <span>{minutes} MIN</span>
             <span class="px-1.5">·</span>


### PR DESCRIPTION
### Motivation
- Define an editorial distinction between living reference notes and timestamped articles without splitting the Astro collection.
- Allow the site to surface updated dates for wiki-style pages while preserving existing routes and link graph behavior.
- Record the rationale for the decision in an ADR for future reference.

### Description
- Add an ADR `docs/decisions/ADR-001-wiki-vs-article-separation.md` documenting the choice to keep one `posts` collection and use a frontmatter discriminator.
- Extend the content schema in `src/content/config.ts` with `type: z.enum(["wiki","article"]).default("wiki")` and `updatedAt: z.coerce.date().optional()` and preserve `tags` normalization.
- Update the index page `src/pages/index.astro` to separate `articles` and `wikis`, show only `article` posts in the list view, keep the graph inclusive, and choose a `featured` post preferring articles before wikis.
- Update the post detail page `src/pages/posts/[...id].astro` to display `UPDATED <date>` when `post.data.type === "wiki"` and `post.data.updatedAt` is present, otherwise fall back to the `createdAt` label.

### Testing
- Performed a TypeScript type check (`tsc --noEmit`) against the modified codebase and it completed successfully.
- Built the site with `npm run build` (`astro build`) and the build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f981b41938832bba6c7201b5ead02c)