### PR TITLE
fix(ci): Stabilize content test setup

### DIFF
--- a/.github/workflows/synchronizer.yml
+++ b/.github/workflows/synchronizer.yml
@@ -14,11 +14,9 @@ jobs:
     permissions:
       contents: write
     outputs:
-      has_changes: ${{ steps.check.outputs.changed}}
+      has_changes: ${{ steps.check.outputs.changed }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Setup SSH
         run: |
@@ -31,7 +29,9 @@ jobs:
       - name: Sync posts to obsidian vault
         id: check
         run: |
-          git submodule update --remote --checkout
+          git submodule sync --recursive
+          git config submodule.src/content/posts.url git@github.com:seheon99/blog-obsidian-vault
+          git submodule update --init --remote --checkout src/content/posts
           if git status --porcelain | grep .; then
             echo "changed=true" >> $GITHUB_OUTPUT
             git config user.name "github-actions[bot]"
@@ -56,7 +56,20 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: automation/content-sync
-          submodules: true
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf "%s" "${{ secrets.SYNC_CONTENTS_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Checkout posts submodule
+        run: |
+          git submodule sync --recursive
+          git config submodule.src/content/posts.url git@github.com:seheon99/blog-obsidian-vault
+          git submodule update --init --checkout src/content/posts
 
       - uses: seheon99/build-and-deploy@v1
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ pnpm vitest run -t "resolves wikilink by title"
 pnpm vitest bench
 ```
 
-`pnpm install` only builds `sharp` from source; other postinstall scripts are blocked via `pnpm.onlyBuiltDependencies`.
+`pnpm install` only builds `sharp` from source; other postinstall scripts are blocked via `pnpm-workspace.yaml`.
 
 ## Repository layout
 
@@ -136,6 +136,6 @@ When a change pivots architecture (rendering posture, a new dependency category,
 
 - **Don't author or commit post markdown from this repo.** `src/content/posts/` is owned by the `blog-obsidian-vault` submodule; the `synchronizer.yml` workflow is the only writer. New fixtures for tests go under `tests/fixtures/posts/`, not into the submodule.
 - **Don't push to `automation/content-sync`.** That branch is force-pushed by the synchronizer workflow on every vault update.
-- **Don't relax `pnpm.onlyBuiltDependencies`.** Postinstall scripts are blocked by design; only `sharp` is whitelisted. Adding a dep that requires postinstall needs an explicit decision.
+- **Don't relax `pnpm-workspace.yaml` build approvals.** Postinstall scripts are blocked by design; only `sharp` is whitelisted. Adding a dep that requires postinstall needs an explicit decision.
 - **Don't enable `fileParallelism` in vitest.** Tests share `.astro/data-store.json`; parallel files race the seeder in `tests/global-setup.ts`.
 - **Don't add a React island without an ADR.** ADR-002's bar (lifecycle, imperative DOM, per-element handlers, cross-page reuse) must be cleared and recorded.

--- a/package.json
+++ b/package.json
@@ -52,10 +52,5 @@
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
     "vitest": "^4.0.16"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "sharp"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - sharp

--- a/tests/fixtures/posts/algorithm-binary-search.md
+++ b/tests/fixtures/posts/algorithm-binary-search.md
@@ -1,6 +1,7 @@
 ---
 title: "Binary search invariants"
 description: "Loop invariants that keep binary search correct on every iteration"
+type: article
 createdAt: 2023-11-04
 tags:
   - Algorithm

--- a/tests/fixtures/posts/diagram-mermaid.md
+++ b/tests/fixtures/posts/diagram-mermaid.md
@@ -1,6 +1,7 @@
 ---
 title: "Mermaid diagrams"
 description: "A small flowchart rendered through Mermaid"
+type: article
 createdAt: 2024-02-15
 tags:
   - Diagrams

--- a/tests/fixtures/posts/javascript-symbol.md
+++ b/tests/fixtures/posts/javascript-symbol.md
@@ -1,6 +1,7 @@
 ---
 title: "JavaScript Symbol"
 description: "Notes on the Symbol primitive in JavaScript"
+type: article
 createdAt: 2024-03-15
 tags:
   - JavaScript

--- a/tests/fixtures/posts/typescript-narrowing.md
+++ b/tests/fixtures/posts/typescript-narrowing.md
@@ -1,6 +1,7 @@
 ---
 title: "TypeScript narrowing"
 description: "How TypeScript narrows union types in control-flow positions"
+type: article
 createdAt: 2024-02-10
 tags:
   - TypeScript

--- a/tests/fixtures/posts/web-platform-streams.md
+++ b/tests/fixtures/posts/web-platform-streams.md
@@ -1,6 +1,7 @@
 ---
 title: "Web Platform streams"
 description: "ReadableStream and WritableStream on the modern web platform"
+type: article
 createdAt: 2024-01-20
 tags:
   - JavaScript

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import {
   copyFileSync,
   existsSync,
+  mkdirSync,
   readdirSync,
   unlinkSync,
 } from "node:fs";
@@ -10,6 +11,11 @@ import path from "node:path";
 const REPO_ROOT = path.resolve(__dirname, "..");
 const FIXTURES_DIR = path.join(REPO_ROOT, "tests/fixtures/posts");
 const POSTS_DIR = path.join(REPO_ROOT, "src/content/posts");
+const ASTRO_BIN = path.join(
+  REPO_ROOT,
+  "node_modules/.bin",
+  process.platform === "win32" ? "astro.CMD" : "astro",
+);
 // `astro sync --mode test` lands data-store.json in cacheDir
 // (node_modules/.astro). The container API spun up by Vitest reads from
 // dotAstroDir (.astro). Copy the produced store across so getCollection()
@@ -17,9 +23,61 @@ const POSTS_DIR = path.join(REPO_ROOT, "src/content/posts");
 const SYNC_OUTPUT = path.join(REPO_ROOT, "node_modules/.astro/data-store.json");
 const RUNTIME_STORE = path.join(REPO_ROOT, ".astro/data-store.json");
 
-function listMarkdown(dir: string): string[] {
+function listMarkdownFiles(dir: string): string[] {
   if (!existsSync(dir)) return [];
-  return readdirSync(dir).filter((f) => f.endsWith(".md"));
+  return readdirSync(dir).filter((file) => file.endsWith(".md"));
+}
+
+function hasMarkdownFile(dir: string): boolean {
+  if (!existsSync(dir)) return false;
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isFile() && entry.name.endsWith(".md")) return true;
+    if (entry.isDirectory() && hasMarkdownFile(fullPath)) return true;
+  }
+  return false;
+}
+
+function unlinkIfExists(filePath: string): void {
+  if (!existsSync(filePath)) return;
+  unlinkSync(filePath);
+}
+
+function syncAstroContent(): void {
+  unlinkIfExists(SYNC_OUTPUT);
+  unlinkIfExists(RUNTIME_STORE);
+
+  try {
+    if (process.platform === "win32") {
+      execFileSync("cmd.exe", ["/d", "/c", "call", ASTRO_BIN, "sync"], {
+        cwd: REPO_ROOT,
+        stdio: "pipe",
+      });
+      return;
+    }
+
+    execFileSync(ASTRO_BIN, ["sync"], {
+      cwd: REPO_ROOT,
+      stdio: "pipe",
+    });
+  } catch (error) {
+    const childError = error as {
+      status?: number;
+      stdout?: Buffer;
+      stderr?: Buffer;
+    };
+    if (
+      process.platform === "win32" &&
+      childError.status === 3221226505 &&
+      existsSync(SYNC_OUTPUT)
+    ) {
+      return;
+    }
+    if (childError.stdout) process.stdout.write(childError.stdout);
+    if (childError.stderr) process.stderr.write(childError.stderr);
+    throw error;
+  }
 }
 
 // `src/content/posts` is a private submodule. When it isn't checked out
@@ -30,8 +88,9 @@ export default function setup() {
   const seeded: string[] = [];
   let copiedStore = false;
 
-  if (listMarkdown(POSTS_DIR).length === 0) {
-    for (const file of listMarkdown(FIXTURES_DIR)) {
+  if (!hasMarkdownFile(POSTS_DIR)) {
+    mkdirSync(POSTS_DIR, { recursive: true });
+    for (const file of listMarkdownFiles(FIXTURES_DIR)) {
       const dest = path.join(POSTS_DIR, file);
       copyFileSync(path.join(FIXTURES_DIR, file), dest);
       seeded.push(dest);
@@ -39,8 +98,9 @@ export default function setup() {
   }
 
   if (seeded.length > 0) {
-    execFileSync("npx", ["astro", "sync"], { cwd: REPO_ROOT, stdio: "inherit" });
+    syncAstroContent();
     if (existsSync(SYNC_OUTPUT)) {
+      mkdirSync(path.dirname(RUNTIME_STORE), { recursive: true });
       copyFileSync(SYNC_OUTPUT, RUNTIME_STORE);
       copiedStore = true;
     }
@@ -56,7 +116,8 @@ export default function setup() {
     }
     if (copiedStore) {
       try {
-        unlinkSync(RUNTIME_STORE);
+        unlinkIfExists(SYNC_OUTPUT);
+        unlinkIfExists(RUNTIME_STORE);
       } catch {
         // ignore cleanup errors
       }


### PR DESCRIPTION
## Purpose

Keep CI, local tests, and content sync reliable when the private posts submodule is unavailable or must be checked out with SSH credentials.

## Changes

- Configure the synchronizer workflow to set up SSH before checking out the private posts submodule.
- Harden Vitest global setup so fixture posts seed cleanly, Astro content data stores are refreshed, and generated stores are cleaned up after tests.
- Mark fixture posts as articles so homepage list/tag filtering tests cover the intended list behavior.
- Move pnpm build-script approval to `pnpm-workspace.yaml`, the current pnpm 10 config location.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm test` passed: 21 files, 187 tests
- `pnpm run lint` passed: 0 errors
- `pnpm build` passed

Note: builds in this checkout warn that `src/content/posts` is empty, which is expected when the private posts submodule content is absent.