### PR TITLE
test(fixtures): Mark seeded posts as articles

### DIFF
--- a/tests/fixtures/posts/algorithm-binary-search.md
+++ b/tests/fixtures/posts/algorithm-binary-search.md
@@ -1,6 +1,7 @@
 ---
 title: "Binary search invariants"
 description: "Loop invariants that keep binary search correct on every iteration"
+type: article
 createdAt: 2023-11-04
 tags:
   - Algorithm

--- a/tests/fixtures/posts/diagram-mermaid.md
+++ b/tests/fixtures/posts/diagram-mermaid.md
@@ -1,6 +1,7 @@
 ---
 title: "Mermaid diagrams"
 description: "A small flowchart rendered through Mermaid"
+type: article
 createdAt: 2024-02-15
 tags:
   - Diagrams

--- a/tests/fixtures/posts/javascript-symbol.md
+++ b/tests/fixtures/posts/javascript-symbol.md
@@ -1,6 +1,7 @@
 ---
 title: "JavaScript Symbol"
 description: "Notes on the Symbol primitive in JavaScript"
+type: article
 createdAt: 2024-03-15
 tags:
   - JavaScript

--- a/tests/fixtures/posts/typescript-narrowing.md
+++ b/tests/fixtures/posts/typescript-narrowing.md
@@ -1,6 +1,7 @@
 ---
 title: "TypeScript narrowing"
 description: "How TypeScript narrows union types in control-flow positions"
+type: article
 createdAt: 2024-02-10
 tags:
   - TypeScript

--- a/tests/fixtures/posts/web-platform-streams.md
+++ b/tests/fixtures/posts/web-platform-streams.md
@@ -1,6 +1,7 @@
 ---
 title: "Web Platform streams"
 description: "ReadableStream and WritableStream on the modern web platform"
+type: article
 createdAt: 2024-01-20
 tags:
   - JavaScript


### PR DESCRIPTION
### Motivation
- The homepage list view only renders posts whose normalized `type` is `article`, and the seeded test fixtures lacked an explicit `type`, defaulting to `wiki` and causing the tag-filter validation to compare against an unrepresentative baseline.

### Description
- Add `type: article` to five seeded Markdown fixtures under `tests/fixtures/posts` so the list-view tag filtering test exercises multiple rendered writing rows (`algorithm-binary-search.md`, `diagram-mermaid.md`, `javascript-symbol.md`, `typescript-narrowing.md`, `web-platform-streams.md`).

### Testing
- Ran `pnpm test` (all tests now pass), `pnpm lint` (no diagnostics), and `pnpm build` (site builds successfully), and the previous failing tag-filter assertion is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ea4034778832ba4f72789f4d88308)